### PR TITLE
Support underscores in integer and float tokens

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -51,15 +51,16 @@ impl Token {
             }
             'A'..='Z' | '_' => VariableToken::from_text(text, pos).map(Token::from),
             '0'..='9' => {
-                let maybe_float = if let Some(i) = text.find(|c: char| !c.is_digit(10)) {
-                    text.as_bytes()[i] == b'.'
-                        && text
-                            .as_bytes()
-                            .get(i + 1)
-                            .map_or(false, |c| (*c as char).is_digit(10))
-                } else {
-                    false
-                };
+                let maybe_float =
+                    if let Some(i) = text.find(|c: char| !(c.is_digit(10) || c == '_')) {
+                        text.as_bytes()[i] == b'.'
+                            && text
+                                .as_bytes()
+                                .get(i + 1)
+                                .map_or(false, |c| (*c as char).is_digit(10))
+                    } else {
+                        false
+                    };
                 if maybe_float {
                     FloatToken::from_text(text, pos).map(Token::from)
                 } else {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -384,11 +384,18 @@ impl fmt::Display for CommentToken {
 /// // Ok
 /// assert_eq!(FloatToken::from_text("0.1", pos.clone()).unwrap().value(), 0.1);
 /// assert_eq!(FloatToken::from_text("12.3e-1  ", pos.clone()).unwrap().value(), 1.23);
+/// assert_eq!(FloatToken::from_text("1_2.3_4e-1_0", pos.clone()).unwrap().value(), 0.000000001234);
 ///
 /// // Err
 /// assert!(FloatToken::from_text("123", pos.clone()).is_err());
 /// assert!(FloatToken::from_text(".123", pos.clone()).is_err());
 /// assert!(FloatToken::from_text("1.", pos.clone()).is_err());
+/// assert!(FloatToken::from_text("12_.3", pos.clone()).is_err());
+/// assert!(FloatToken::from_text("12._3", pos.clone()).is_err());
+/// assert!(FloatToken::from_text("12.3_", pos.clone()).is_err());
+/// assert!(FloatToken::from_text("1__2.3", pos.clone()).is_err());
+/// assert!(FloatToken::from_text("12.3__4", pos.clone()).is_err());
+/// assert!(FloatToken::from_text("12.34e-1__0", pos.clone()).is_err());
 /// ```
 #[derive(Debug, Clone)]
 pub struct FloatToken {
@@ -415,43 +422,54 @@ impl FloatToken {
 
     /// Tries to convert from any prefixes of the text to a `FloatToken`.
     pub fn from_text(text: &str, pos: Position) -> Result<Self> {
-        let mut chars = text.char_indices().peekable();
+        fn read_digits(
+            buf: &mut String,
+            chars: &mut std::iter::Peekable<impl Iterator<Item = (usize, char)>>,
+            pos: &Position,
+        ) -> Result<()> {
+            let mut needs_digit = true;
+            while let Some((_, c @ ('0'..='9' | '_'))) = chars.peek().cloned() {
+                if c == '_' {
+                    if needs_digit {
+                        break;
+                    }
+                    needs_digit = true;
+                } else {
+                    buf.push(c);
+                    needs_digit = false;
+                }
+                let _ = chars.next();
+            }
+            if needs_digit {
+                Err(Error::invalid_float_token(pos.clone()))
+            } else {
+                Ok(())
+            }
+        }
 
-        while let Some((_, '0'..='9')) = chars.peek().cloned() {
-            let _ = chars.next();
-        }
-        if chars.peek().map(|&(i, _)| i) == Some(0) {
-            return Err(Error::invalid_float_token(pos));
-        }
+        let mut chars = text.char_indices().peekable();
+        let mut buf = String::new();
+        read_digits(&mut buf, &mut chars, &pos)?;
         if chars.next().map(|(_, c)| c) != Some('.') {
             return Err(Error::invalid_float_token(pos));
         }
-        if !chars.next().map_or(false, |(_, c)| c.is_digit(10)) {
-            return Err(Error::invalid_float_token(pos));
-        }
+        buf.push('.');
 
-        while let Some((_, '0'..='9')) = chars.peek().cloned() {
+        read_digits(&mut buf, &mut chars, &pos)?;
+
+        if let Some((_, c @ ('e' | 'E'))) = chars.peek().cloned() {
             let _ = chars.next();
-        }
-        if let Some((_, 'e')) = chars.peek().cloned() {
-            let _ = chars.next();
-        }
-        if let Some((_, 'E')) = chars.peek().cloned() {
-            let _ = chars.next();
-        }
-        if let Some((_, '+')) = chars.peek().cloned() {
-            let _ = chars.next();
-        }
-        if let Some((_, '-')) = chars.peek().cloned() {
-            let _ = chars.next();
-        }
-        while let Some((_, '0'..='9')) = chars.peek().cloned() {
-            let _ = chars.next();
+            buf.push(c);
+            if let Some((_, c @ ('+' | '-'))) = chars.peek().cloned() {
+                let _ = chars.next();
+                buf.push(c);
+            }
+            read_digits(&mut buf, &mut chars, &pos)?;
         }
 
         let end = chars.next().map(|(i, _)| i).unwrap_or_else(|| text.len());
         let text = unsafe { text.get_unchecked(0..end) }.to_owned();
-        let value = text
+        let value = buf
             .parse()
             .map_err(|_| Error::invalid_float_token(pos.clone()))?;
         Ok(FloatToken { value, text, pos })

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -21,8 +21,23 @@ fn tokenize_comments() {
 
 #[test]
 fn tokenize_numbers() {
-    let src = "10 1.02";
-    assert_eq!(tokenize!(src), ["10", " ", "1.02"]);
+    let src = "10 1_2_3 1_6#10 1.02 1.2_3e+1_0 1_0.0";
+    assert_eq!(
+        tokenize!(src),
+        [
+            "10",
+            " ",
+            "1_2_3",
+            " ",
+            "1_6#10",
+            " ",
+            "1.02",
+            " ",
+            "1.2_3e+1_0",
+            " ",
+            "1_0.0"
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR makes it possible to parse integers and floats such as `1_2_3` or `1.2_3e1_0` and so on.