### PR TITLE
Support EEP-49 (`maybe` syntax)

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -996,6 +996,7 @@ impl SymbolToken {
                 b">=" => Some(Symbol::GreaterEq),
                 b"=<" => Some(Symbol::LessEq),
                 b"??" => Some(Symbol::DoubleQuestion),
+                b"?=" => Some(Symbol::MaybeMatch),
                 b".." => Some(Symbol::DoubleDot),
                 _ => None,
             };

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -743,6 +743,8 @@ impl KeywordToken {
             "try" => Keyword::Try,
             "when" => Keyword::When,
             "xor" => Keyword::Xor,
+            "maybe" => Keyword::Maybe,
+            "else" => Keyword::Else,
             s => return Err(Error::unknown_keyword(pos, s.to_owned())),
         };
         Ok(KeywordToken { value, pos })

--- a/src/values.rs
+++ b/src/values.rs
@@ -197,6 +197,9 @@ pub enum Symbol {
     /// `??`
     DoubleQuestion,
 
+    /// `?=`
+    MaybeMatch,
+
     /// `!`
     Not,
 
@@ -302,6 +305,7 @@ impl Symbol {
             Symbol::GreaterEq => ">=",
             Symbol::Less => "<",
             Symbol::LessEq => "=<",
+            Symbol::MaybeMatch => "?=",
         }
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -87,6 +87,12 @@ pub enum Keyword {
 
     /// `xor`
     Xor,
+
+    /// `maybe`
+    Maybe,
+
+    /// `else`
+    Else,
 }
 impl Keyword {
     /// Returns the string representation of this keyword.
@@ -119,6 +125,8 @@ impl Keyword {
             Keyword::Try => "try",
             Keyword::When => "when",
             Keyword::Xor => "xor",
+            Keyword::Maybe => "maybe",
+            Keyword::Else => "else",
         }
     }
 }


### PR DESCRIPTION
This PR adds the following keywords and a symbol to support [EEP-49](https://github.com/erlang/eep/blob/master/eeps/eep-0049.md):
- `maybe` keyword
- `else` keyword
- `?=` symbol