### PR TITLE
Fix adjacent strings error position

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1001,6 +1001,7 @@ impl StringToken {
             util::parse_quotation(pos.clone(), tail, '"').map(|(v, end)| (v, end + 2))?
         };
         if text.get(end..end + 1) == Some("\"") {
+            let pos = pos.step_by_text(&text[0..end]);
             return Err(Error::adjacent_string_literals(pos));
         }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -63,11 +63,11 @@ fn tokenize_strings() {
 
 #[test]
 fn tokenize_triple_quoted_strings() {
-    fn tokenize(text: &str) -> Option<String> {
-        if let Some(Ok(Token::String(t))) = Tokenizer::new(text).next() {
-            Some(t.value().to_owned())
-        } else {
-            None
+    fn tokenize(text: &str) -> Result<String, usize> {
+        match Tokenizer::new(text).next() {
+            Some(Ok(Token::String(t))) => Ok(t.value().to_owned()),
+            Some(Err(e)) => Err(e.position().offset()),
+            t => panic!("{t:?}"),
         }
     }
 
@@ -75,45 +75,45 @@ fn tokenize_triple_quoted_strings() {
     let src = r#""""
 foo
 """"#;
-    assert_eq!(tokenize(src), Some("foo".to_owned()));
+    assert_eq!(tokenize(src), Ok("foo".to_owned()));
 
     let src = r#""""
  foo
  """"#;
-    assert_eq!(tokenize(src), Some("foo".to_owned()));
+    assert_eq!(tokenize(src), Ok("foo".to_owned()));
 
     let src = r#"""""
 foo
 """""#;
-    assert_eq!(tokenize(src), Some("foo".to_owned()));
+    assert_eq!(tokenize(src), Ok("foo".to_owned()));
 
     let src = r#""""
 """"#;
-    assert_eq!(tokenize(src), Some("".to_owned()));
+    assert_eq!(tokenize(src), Ok("".to_owned()));
 
     let src = r#""""
 
 """"#;
-    assert_eq!(tokenize(src), Some("".to_owned()));
+    assert_eq!(tokenize(src), Ok("".to_owned()));
 
     let src = r#""""
 
 
 """"#;
-    assert_eq!(tokenize(src), Some("\n".to_owned()));
+    assert_eq!(tokenize(src), Ok("\n".to_owned()));
 
     // NG
     let src = r#""""foo""""#;
-    assert_eq!(tokenize(src), None);
+    assert_eq!(tokenize(src), Err(0));
 
     let src = r#""""\nfoo\n """"#;
-    assert_eq!(tokenize(src), None);
+    assert_eq!(tokenize(src), Err(0));
 
     let src = r#""""erl\nfoo\n""""#;
-    assert_eq!(tokenize(src), None);
+    assert_eq!(tokenize(src), Err(0));
 
     let src = r#""a""b""#; // Strings concatenation without intervening whitespace
-    assert_eq!(tokenize(src), None);
+    assert_eq!(tokenize(src), Err(3));
 }
 
 #[test]


### PR DESCRIPTION
This pull request includes changes in two Rust files, `src/tokens.rs` and `tests/lib.rs`. The changes primarily focus on error handling and testing improvements. The most important changes include the addition of a position step in `StringToken` to handle adjacent string literals and the modification of the `tokenize` function in `tokenize_triple_quoted_strings` to return a `Result` instead of an `Option`.

Error Handling:

* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R1004): In the `StringToken` struct, a position step has been added to handle adjacent string literals. This change should help provide more accurate error messages when adjacent string literals are encountered.

Testing Improvements:

* [`tests/lib.rs`](diffhunk://#diff-6d1e3ec7ab6aaf7a94f9c1e9a423db6de6e4a1bec380dae17cc6e635f1db8854L66-R116): The `tokenize` function in the `tokenize_triple_quoted_strings` test has been modified to return a `Result` instead of an `Option`. This allows for more precise error handling in the test, as it can now distinguish between different types of errors and their positions. The assertions in the test have been updated accordingly to check for `Ok` and `Err` results.