### PR TITLE
Remove `thiseror` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 
 [dependencies]
 num = { version = "0.4", features = ["serde"] }
-thiserror = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,68 +1,53 @@
 use crate::Position;
 
 /// Possible errors.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum Error {
     /// No closing quotation.
-    #[error("no closing quotation ({position})")]
     NoClosingQuotation { position: Position },
 
     /// Invalid escaped character.
-    #[error("cannot parse a escaped character ({position})")]
     InvalidEscapedChar { position: Position },
 
     /// Adjacent string literals without intervening white space.
-    #[error("adjacent string literals without intervening white space ({position})")]
     AdjacentStringLiterals { position: Position },
 
     /// A token was expected, but not found.
-    #[error("a token was expected, but not found ({position})")]
     MissingToken { position: Position },
 
     /// Unknown keyword.
-    #[error("unknown keyword {keyword:?} ({position})")]
     UnknownKeyword { position: Position, keyword: String },
 
     /// Invalid atom token.
-    #[error("Canot parse an atom token ({position})")]
     InvalidAtomToken { position: Position },
 
     /// Invalid character token.
-    #[error("cannot parse a character token ({position})")]
     InvalidCharToken { position: Position },
 
     /// Invalid comment token.
-    #[error("cannot parse a comment token ({position})")]
     InvalidCommentToken { position: Position },
 
     /// Invalid float token.
-    #[error("cannot parse a float token ({position})")]
     InvalidFloatToken { position: Position },
 
     /// Invalid integer token.
-    #[error("cannot parse a integer token ({position})")]
     InvalidIntegerToken { position: Position },
 
     /// Invalid string token.
-    #[error("cannot parse a string token ({position})")]
     InvalidStringToken { position: Position },
 
     /// Invalid sigil string token.
-    #[error("cannot parse a sigil string token ({position})")]
     InvalidSigilStringToken { position: Position },
 
     /// Invalid symbol token.
-    #[error("cannot parse a symbol token ({position})")]
     InvalidSymbolToken { position: Position },
 
     /// Invalid variable token.
-    #[error("cannot parse a variable token ({position})")]
     InvalidVariableToken { position: Position },
 
     /// Invalid whitespace token.
-    #[error("cannot parse a whitespace token ({position})")]
     InvalidWhitespaceToken { position: Position },
 }
 
@@ -148,3 +133,60 @@ impl Error {
         Self::InvalidWhitespaceToken { position }
     }
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::NoClosingQuotation { position } => {
+                write!(f, "no closing quotation ({position})")
+            }
+            Error::InvalidEscapedChar { position } => {
+                write!(f, "cannot parse a escaped character ({position})")
+            }
+            Error::AdjacentStringLiterals { position } => {
+                write!(
+                    f,
+                    "adjacent string literals without intervening white space ({position})"
+                )
+            }
+            Error::MissingToken { position } => {
+                write!(f, "a token was expected, but not found ({position})")
+            }
+            Error::UnknownKeyword { position, keyword } => {
+                write!(f, "unknown keyword {keyword:?} ({position})")
+            }
+            Error::InvalidAtomToken { position } => {
+                write!(f, "cannot parse an atom token ({position})")
+            }
+            Error::InvalidCharToken { position } => {
+                write!(f, "cannot parse a character token ({position})")
+            }
+            Error::InvalidCommentToken { position } => {
+                write!(f, "cannot parse a comment token ({position})")
+            }
+            Error::InvalidFloatToken { position } => {
+                write!(f, "cannot parse a float token ({position})")
+            }
+            Error::InvalidIntegerToken { position } => {
+                write!(f, "cannot parse a integer token ({position})")
+            }
+            Error::InvalidStringToken { position } => {
+                write!(f, "cannot parse a string token ({position})")
+            }
+            Error::InvalidSigilStringToken { position } => {
+                write!(f, "cannot parse a sigil string token ({position})")
+            }
+            Error::InvalidSymbolToken { position } => {
+                write!(f, "cannot parse a symbol token ({position})")
+            }
+            Error::InvalidVariableToken { position } => {
+                write!(f, "cannot parse a variable token ({position})")
+            }
+            Error::InvalidWhitespaceToken { position } => {
+                write!(f, "cannot parse a whitespace token ({position})")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}


### PR DESCRIPTION
Copilot Summary
--------------------

This pull request includes changes to the error handling in the project by removing the `thiserror` dependency and implementing the `Display` and `Error` traits manually for the `Error` enum. The most important changes include modifications to the `Cargo.toml` file and updates to the `src/error.rs` file.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16): Removed the `thiserror` dependency.

Error handling updates:

* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL4-L65): Removed the `thiserror::Error` derive macro from the `Error` enum and manually implemented the `std::fmt::Display` trait for all error variants. [[1]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eL4-L65) [[2]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR136-R192)
* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR136-R192): Implemented the `std::error::Error` trait for the `Error` enum.