### PR TITLE
Use `num-bigint` instead of `num`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-num = { version = "0.4", features = ["serde"] }
+num-bigint = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive", "rc"] }
 
 [dev-dependencies]

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,5 +1,5 @@
 //! Tokens.
-use num::{BigUint, Num};
+use num_bigint::BigUint;
 use std::borrow::Cow;
 use std::fmt;
 use std::str;
@@ -609,8 +609,8 @@ impl IntegerToken {
         }
 
         let end = chars.peek().map(|&(i, _)| i).unwrap_or_else(|| text.len());
-        let value = Num::from_str_radix(&digits, radix)
-            .map_err(|_| Error::invalid_integer_token(pos.clone()))?;
+        let value = BigUint::parse_bytes(digits.as_bytes(), radix)
+            .ok_or_else(|| Error::invalid_integer_token(pos.clone()))?;
         let text = unsafe { text.get_unchecked(0..end) }.to_owned();
         Ok(IntegerToken { value, text, pos })
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 use crate::{Error, Position, Result};
-use num::Num;
 use std::borrow::Cow;
 use std::char;
 use std::iter::Peekable;
@@ -92,7 +91,7 @@ where
                 buf.push(chars.next().map(|(_, c)| c).ok_or_else(error)?);
                 buf
             };
-            let code: u32 = Num::from_str_radix(&buf, 16).ok().ok_or_else(error)?;
+            let code: u32 = u32::from_str_radix(&buf, 16).ok().ok_or_else(error)?;
             char::from_u32(code).ok_or_else(error)
         }
         c @ '0'..='7' => {


### PR DESCRIPTION
To reduce unnecessary dependencies.

Copilot Summary
---------------

This pull request includes several changes to update the codebase to use `num-bigint` instead of the `num` crate for handling big integers. The most important changes are as follows:

Dependency Update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15): Replaced the `num` crate with the `num-bigint` crate for handling big integers.

Code Adjustments:
* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L2-R2): Updated imports and modified the `IntegerToken` implementation to use `num_bigint::BigUint` and `BigUint::parse_bytes` instead of `Num::from_str_radix`. [[1]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L2-R2) [[2]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L612-R613)
* [`src/util.rs`](diffhunk://#diff-4007187965c1fea4fd252a76f5f1007b2ea59f6d86e2f454edee547c5036be24L2): Updated imports and changed the code conversion logic to use `u32::from_str_radix` instead of `Num::from_str_radix`. [[1]](diffhunk://#diff-4007187965c1fea4fd252a76f5f1007b2ea59f6d86e2f454edee547c5036be24L2) [[2]](diffhunk://#diff-4007187965c1fea4fd252a76f5f1007b2ea59f6d86e2f454edee547c5036be24L95-R94)