### PR TITLE
Add `&&`, `<:-`, and `<:=` symbols that will be introduced in OTP-28

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1207,6 +1207,8 @@ impl SymbolToken {
                 b"=:=" => Some(Symbol::ExactEq),
                 b"=/=" => Some(Symbol::ExactNotEq),
                 b"..." => Some(Symbol::TripleDot),
+                b"<:-" => Some(Symbol::StrictLeftArrow),
+                b"<:=" => Some(Symbol::StrictDoubleLeftArrow),
                 _ => None,
             }
         } else {
@@ -1232,6 +1234,7 @@ impl SymbolToken {
                 b"??" => Some(Symbol::DoubleQuestion),
                 b"?=" => Some(Symbol::MaybeMatch),
                 b".." => Some(Symbol::DoubleDot),
+                b"&&" => Some(Symbol::DoubleAmpersand),
                 _ => None,
             };
         }

--- a/src/values.rs
+++ b/src/values.rs
@@ -259,6 +259,15 @@ pub enum Symbol {
 
     /// `=<`
     LessEq,
+
+    /// `&&`
+    DoubleAmpersand,
+
+    /// `<:-`
+    StrictLeftArrow,
+
+    /// `<:=`
+    StrictDoubleLeftArrow,
 }
 impl Symbol {
     /// Returns the textual representation of this symbol.
@@ -306,6 +315,9 @@ impl Symbol {
             Symbol::Less => "<",
             Symbol::LessEq => "=<",
             Symbol::MaybeMatch => "?=",
+            Symbol::DoubleAmpersand => "&&",
+            Symbol::StrictLeftArrow => "<:-",
+            Symbol::StrictDoubleLeftArrow => "<:=",
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -193,3 +193,15 @@ fn tokenize_multibyte_whitespaces() {
     let src = "a\u{a0}b";
     assert_eq!(tokenize!(src), ["a", "\u{a0}", "b"]);
 }
+
+#[test]
+fn tokenize_symbols() {
+    let src = r#"[ 0 || x <:- [] && y <:= <<>> ]"#;
+    assert_eq!(
+        tokenize!(src),
+        [
+            "[", " ", "0", " ", "||", " ", "x", " ", "<:-", " ", "[", "]", " ", "&&", " ", "y",
+            " ", "<:=", " ", "<<", ">>", " ", "]"
+        ]
+    );
+}


### PR DESCRIPTION
Copilot  Summary 
---

This pull request introduces several new symbols to the tokenizer and updates the relevant tests to ensure proper functionality. The changes involve adding new symbols to the `Symbol` enum and updating the tokenization logic to recognize these symbols.

### Addition of new symbols:

* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R1210-R1211): Added support for the symbols `StrictLeftArrow`, `StrictDoubleLeftArrow`, and `DoubleAmpersand` in the `impl SymbolToken` match arms. [[1]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R1210-R1211) [[2]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R1237)

* [`src/values.rs`](diffhunk://#diff-7660abb03c57ce5b114cdd192575b48efa04f71fa64774629765968c878194c8R262-R270): Updated the `Symbol` enum to include `DoubleAmpersand`, `StrictLeftArrow`, and `StrictDoubleLeftArrow`. Also updated the `impl Symbol` to return the correct textual representation for these new symbols. [[1]](diffhunk://#diff-7660abb03c57ce5b114cdd192575b48efa04f71fa64774629765968c878194c8R262-R270) [[2]](diffhunk://#diff-7660abb03c57ce5b114cdd192575b48efa04f71fa64774629765968c878194c8R318-R320)

### Test updates:

* [`tests/lib.rs`](diffhunk://#diff-6d1e3ec7ab6aaf7a94f9c1e9a423db6de6e4a1bec380dae17cc6e635f1db8854R196-R207): Added a new test function `tokenize_symbols` to verify that the tokenizer correctly processes the new symbols.