### PR TITLE
Fix a bug that incorrectly determines whether the next token is a based float (EEP 75) or not

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -388,7 +388,7 @@ impl fmt::Display for CommentToken {
 /// assert_eq!(FloatToken::from_text("2#0.111", pos.clone()).unwrap().value(), 0.875);
 /// assert_eq!(FloatToken::from_text("2#0.10101#e8", pos.clone()).unwrap().value(), 168.0);
 /// assert_eq!(FloatToken::from_text("16#f_f.F_F", pos.clone()).unwrap().value(), 255.99609375);
-/// assert_eq!(FloatToken::from_text("16#fefe.fefe#e16", pos.clone()).unwrap().value(), 1.2041849337671418e24);
+/// assert_eq!(FloatToken::from_text("1_6#fefe.fefe#e1_6", pos.clone()).unwrap().value(), 1.2041849337671418e24);
 /// assert_eq!(FloatToken::from_text("32#vrv.vrv#e15", pos.clone()).unwrap().value(), 1.2331041872800477e27);
 ///
 /// // Err

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -407,6 +407,7 @@ impl fmt::Display for CommentToken {
 /// assert!(FloatToken::from_text("10#1__2.3", pos.clone()).is_err());
 /// assert!(FloatToken::from_text("12.3__4", pos.clone()).is_err());
 /// assert!(FloatToken::from_text("10#12.3__4", pos.clone()).is_err());
+/// assert!(FloatToken::from_text("10_#12.34", pos.clone()).is_err());
 /// assert!(FloatToken::from_text("12.34e-1__0", pos.clone()).is_err());
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -504,12 +505,33 @@ impl FloatToken {
         false
     }
 
+    fn parse_digits<T: std::str::FromStr>(text: &str, pos: &Position) -> Result<T> {
+        let mut s = String::new();
+        let mut is_prev_digit = false;
+        for (i, c) in text.char_indices() {
+            if i == 0 && c == '-' {
+                s.push(c);
+                is_prev_digit = false;
+            } else if matches!(c, '0'..='9') {
+                s.push(c);
+                is_prev_digit = true;
+            } else if is_prev_digit && c == '_' {
+                is_prev_digit = false;
+            } else {
+                return Err(Error::invalid_float_token(pos.clone()));
+            }
+        }
+        if !is_prev_digit {
+            return Err(Error::invalid_float_token(pos.clone()));
+        }
+        s.parse::<T>()
+            .map_err(|_| Error::invalid_float_token(pos.clone()))
+    }
+
     fn from_text_radix(text: &str, pos: Position) -> Result<Self> {
         let s = text;
         let i = s.find('#').expect("infallible");
-        let radix: u32 = s[..i]
-            .parse()
-            .map_err(|_| Error::invalid_float_token(pos.clone()))?;
+        let radix = Self::parse_digits(&s[..i], &pos)?;
         if !(1 < radix && radix < 37) {
             return Err(Error::invalid_float_token(pos));
         }
@@ -579,11 +601,9 @@ impl FloatToken {
             s = &s[1..];
             let i = s
                 .char_indices()
-                .position(|(i, c)| !((i == 0 && c == '-') || c.is_ascii_digit()))
+                .position(|(i, c)| !((i == 0 && c == '-') || matches!(c, '0'..='9' | '_')))
                 .unwrap_or(s.len());
-            let exp: i32 = s[..i]
-                .parse()
-                .map_err(|_| Error::invalid_float_token(pos.clone()))?;
+            let exp: i32 = Self::parse_digits(&s[..i], &pos)?;
             value *= (radix as f64).powi(exp);
             s = &s[i..];
         }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -434,7 +434,7 @@ impl FloatToken {
 
     /// Tries to convert from any prefixes of the text to a `FloatToken`.
     pub fn from_text(text: &str, pos: Position) -> Result<Self> {
-        if text.contains('#') {
+        if Self::is_based(text) {
             return Self::from_text_radix(text, pos);
         }
 
@@ -489,6 +489,19 @@ impl FloatToken {
             .parse()
             .map_err(|_| Error::invalid_float_token(pos.clone()))?;
         Ok(FloatToken { value, text, pos })
+    }
+
+    fn is_based(text: &str) -> bool {
+        for (i, c) in text.char_indices() {
+            if matches!(c, '0'..='9' | '_') {
+                continue;
+            }
+            if i > 0 && c == '#' {
+                return true;
+            }
+            break;
+        }
+        false
     }
 
     fn from_text_radix(text: &str, pos: Position) -> Result<Self> {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -512,7 +512,7 @@ impl FloatToken {
             if i == 0 && c == '-' {
                 s.push(c);
                 is_prev_digit = false;
-            } else if matches!(c, '0'..='9') {
+            } else if c.is_ascii_digit() {
                 s.push(c);
                 is_prev_digit = true;
             } else if is_prev_digit && c == '_' {


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes several changes to the `FloatToken` implementation in the `src/tokens.rs` file, focusing on improving the handling of numeric bases and digit parsing. The most important changes include modifying the `from_text` method, adding new helper methods, and updating test cases.

Improvements to `FloatToken` implementation:

* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L437-R438): Modified the `from_text` method to use the new `is_based` helper method for checking if the text contains a base indicator.
* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R495-R534): Added the `is_based` helper method to determine if the text contains a base indicator.
* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R495-R534): Added the `parse_digits` helper method to handle digit parsing with support for underscores.

Updates to test cases:

* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L391-R391): Updated test cases to include underscores in the base and exponent parts of the float token text. [[1]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L391-R391) [[2]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R410)

Refactoring:

* [`src/tokens.rs`](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L569-R606): Refactored the `from_text_radix` method to use the new `parse_digits` helper method for parsing the radix and exponent parts.