### PR TITLE
Fix UTF-8 character boundary handling in `Tokenizer::consume_char()`

### DIFF
--- a/src/position.rs
+++ b/src/position.rs
@@ -74,7 +74,7 @@ impl Position {
             self.line += 1;
             self.column = 1;
         } else {
-            self.offset += 1;
+            self.offset += c.len_utf8();
             self.column += 1;
         }
         self

--- a/src/position.rs
+++ b/src/position.rs
@@ -69,12 +69,11 @@ impl Position {
     }
 
     pub(crate) fn step_by_char(mut self, c: char) -> Position {
+        self.offset += c.len_utf8();
         if c == '\n' {
-            self.offset += 1;
             self.line += 1;
             self.column = 1;
         } else {
-            self.offset += c.len_utf8();
             self.column += 1;
         }
         self

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -163,3 +163,33 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // https://github.com/sile/erlls/issues/5
+    //
+    // v0.8.1 caused the following error:
+    // ```
+    // thread 'tokenizer::tests::erlls_issue_5' panicked at src/tokenizer.rs:133:44:
+    // byte index 32 is not a char boundary; it is inside '应' (bytes 31..34) of `-module(repro).
+    // -moduledoc """
+    // 应该报错
+    // "".`
+    // ```
+    #[test]
+    fn erlls_issue_5() {
+        let text = r#"-module(repro).
+-moduledoc """
+应该报错
+""."#;
+        let mut tokenizer = Tokenizer::new(text);
+        while let Some(token) = tokenizer.next() {
+            let Ok(_token) = token else {
+                tokenizer.consume_char();
+                continue;
+            };
+        }
+    }
+}


### PR DESCRIPTION
Related issue: https://github.com/sile/erlls/issues/5